### PR TITLE
Small improvements

### DIFF
--- a/src/main/java/de/psjahn/blurredwindow/XLib.java
+++ b/src/main/java/de/psjahn/blurredwindow/XLib.java
@@ -15,9 +15,18 @@ public interface XLib extends Library {
     @SuppressWarnings("UnusedReturnValue")
     int XChangeProperty(long displayPtr, long window, long/*Atom*/ property, long/*Atom*/ type, int format, int mode, ByteBuffer data, int nElements);
 
+    @SuppressWarnings("UnusedReturnValue")
+    int XDeleteProperty(long displayPtr, long window, long/*Atom*/ property);
+
     static void setBlurBehind(long display, long window, boolean enabled) {
-        long property = XLib.INSTANCE.XInternAtom(display, "_KDE_NET_WM_BLUR_BEHIND_REGION", false);
-        byte[] data = enabled ? new byte[]{ 0x00, 0x00, 0x00, 0x01 } : new byte[]{ 0x00, 0x00, 0x00, 0x00 }; // A boolean but in 32 bit and passed as pointer to buffer "data"
-        XLib.INSTANCE.XChangeProperty(display, window, property, XLib.XA_CARDINAL_ATOM, 32, 0, ByteBuffer.wrap(data), 1);
+        long propertyAtom = XLib.INSTANCE.XInternAtom(display, "_KDE_NET_WM_BLUR_BEHIND_REGION", false);
+
+        if(enabled) {
+            // 32 bit value and passed as pointer to buffer "data". Value doesn't seem to matter, but let's just use 0x01
+            byte[] data = new byte[]{0x00, 0x00, 0x00, 0x01};
+            XLib.INSTANCE.XChangeProperty(display, window, propertyAtom, XLib.XA_CARDINAL_ATOM, 32, 0, ByteBuffer.wrap(data), 1);
+        }else {
+            XLib.INSTANCE.XDeleteProperty(display, window, propertyAtom);
+        }
     }
 }


### PR DESCRIPTION
Hi again :D

Just some small changes, that i think are worth adding:

## Fix disabling BlurBehind on X11

Seems my assumption that the value of `_KDE_NET_WM_BLUR_BEHIND_REGION` is a boolean, was false. It's either some magic value, some other weird usage or it's just plainly ignored. I changed it to remove the property, when disabling the blur behind effect is requested. This seems to properly work as I tested running the method `XLib.setBlurBehind` from my mod during runtime now (where it wouldn't do anything before):

BlurBehind On (unchanged):

![screenshot0005-37](https://github.com/PSJahn/blurredwindow/assets/117233381/b3a6ade7-83bd-4e1c-badb-38521183bb79)

BlurBehind Off:

![screenshot0005-38](https://github.com/PSJahn/blurredwindow/assets/117233381/bd359174-b5e4-4f55-91e6-af4ec060c48c)

---

## Small mixin tweak

I also changed one mixin to use @WrapOperation instead of @Redirect. Mixin-Extras is nowadays builtin to fabric and it seems recommended to prefer using that operation as it can be chained. See [Wiki](https://github.com/LlamaLad7/MixinExtras/wiki/WrapOperation)

The other mixins that do redirect, don't need to be updated as @WrapOperation is not useful if the original method is never intended to be called anyway.

---

Again worth mentioning: This mod is awesome! It really makes Minecraft feel modern in a very unique way!