### PR TITLE
Load libX11 by correct library name

### DIFF
--- a/src/main/java/de/psjahn/blurredwindow/XLib.java
+++ b/src/main/java/de/psjahn/blurredwindow/XLib.java
@@ -6,7 +6,7 @@ import com.sun.jna.Native;
 import java.nio.ByteBuffer;
 
 public interface XLib extends Library {
-    XLib INSTANCE = Native.load("libX11", XLib.class);
+    XLib INSTANCE = Native.load("X11", XLib.class);
 
     long XA_CARDINAL_ATOM = 6;
 


### PR DESCRIPTION
The library name passed is automatically prefixed with `lib`, so previously it would try to load `liblibX11.so` and fail.

I'm not sure how this worked for other people when testing. Hopefully it still does?